### PR TITLE
Bib file for Joss paper

### DIFF
--- a/joss-paper/joss.bib
+++ b/joss-paper/joss.bib
@@ -21,81 +21,52 @@
 }
 
 @article{singh2017microbiome,
-	title={Microbiome and the future for food and nutrient security},
-	author={Singh, Brajesh K and Trivedi, Pankaj},
-	journal={Microbial biotechnology},
-	volume={10},
-	number={1},
-	pages={50},
-	year={2017},
-	publisher={Wiley-Blackwell}
+	author = {Singh, Brajesh K. and Trivedi, Pankaj},
+	title = {Microbiome and the future for food and nutrient security},
+	journal = {Microbial Biotechnology},
+	volume = {10},
+	number = {1},
+	pages = {50-53},
+	doi = {https://doi.org/10.1111/1751-7915.12592},
+	url = {https://ami-journals.onlinelibrary.wiley.com/doi/abs/10.1111/1751-7915.12592},
+	eprint = {https://ami-journals.onlinelibrary.wiley.com/doi/pdf/10.1111/1751-7915.12592},
+	abstract = {Microbiome and the future for food and nutrient security},
+	year = {2017}
 }
 
-@article{torrazza2011developing,
+@Article{torrazza2011developing,
+	author={Torrazza, R. Murgas and Neu, J.},
 	title={The developing intestinal microbiome and its relationship to health and disease in the neonate},
-	author={Torrazza, R Murgas and Neu, J},
 	journal={Journal of Perinatology},
+	year={2011},
+	month={Apr},
+	day={01},
 	volume={31},
 	number={1},
 	pages={S29--S34},
-	year={2011},
-	publisher={Nature Publishing Group}
-}
-
-@article{mckinney2011pandas,
-	title={pandas: a foundational Python library for data analysis and statistics},
-	author={McKinney, Wes and others},
-	journal={Python for high performance and scientific computing},
-	volume={14},
-	number={9},
-	pages={1--9},
-	year={2011},
-	publisher={Seattle}
-}
-
-@misc{google2023,
-    author = {Google Scholar},
-    title = {Google Scholar},
-    howpublished = {\url{https://scholar.google.com/}},
-    year = {2023},
-    note = {Accessed on April 20, 2023}
+	abstract={The intestinal microbiota normally exists in a commensal and/or symbiotic relationship with the host. In the past few years, emerging technologies derived largely from the Human Genome Project have been applied to evaluating the intestinal microbiota and new discoveries using these techniques have prompted new initiatives such as the Human Microbiome Roadmap designed to evaluate the role of the intestinal microbiome in health and disease. In this review, we wish to focus on some new developments in this area and discuss some of the effects of medical manipulations such as antibiotics, probiotics, prebiotics and C-section versus vaginal delivery on the intestinal microbiota.},
+	issn={1476-5543},
+	doi={10.1038/jp.2010.172},
+	url={https://doi.org/10.1038/jp.2010.172}
 }
 
 @misc{pdmice,
-    author = {The QIIME 2 Project},
-    title = {Parkinson’s Mouse Tutorial},
-    howpublished = {\url{https://docs.qiime2.org/2023.2/tutorials/pd-mice/}},
-    year = {2023},
-    note = {Accessed on April 20, 2023}
+	author = {The QIIME 2 Project},
+	title = {Parkinson’s Mouse Tutorial},
+	howpublished = {\url{https://docs.qiime2.org/2023.2/tutorials/pd-mice/}},
+	year = {2023},
+	note = {Accessed on April 20, 2023}
 }
 
 @article{mandal2015analysis,
-  title={Analysis of composition of microbiomes: a novel method for studying microbial composition},
-  author={Mandal, Siddhartha and Van Treuren, Will and White, Richard A and Eggesb{\o}, Merete and Knight, Rob and Peddada, Shyamal D},
-  journal={Microbial ecology in health and disease},
-  volume={26},
-  number={1},
-  pages={27663},
-  year={2015},
-  publisher={Taylor \& Francis}
-}
-
-@article{hagberg2020networkx,
-	title	={NetworkX: Network Analysis with Python},
-	author	={Hagberg, Aric and Conway, Drew},
-    note    = {Accessed: 11 April 2023},
-    howpublished = {https://networkx.org/},
-	year	={2020}
-}
-
-@article{csardi2006igraph,
-	title={The igraph software package for complex network research},
-	author={Csardi, Gabor and Nepusz, Tamas and others},
-	journal={InterJournal, complex systems},
-	volume={1695},
-	number={5},
-	pages={1--9},
-	year={2006}
+	title={Analysis of composition of microbiomes: a novel method for studying microbial composition},
+	author={Mandal, Siddhartha and Van Treuren, Will and White, Richard A and Eggesb{\o}, Merete and Knight, Rob and Peddada, Shyamal D},
+	journal={Microbial ecology in health and disease},
+	volume={26},
+	number={1},
+	pages={27663},
+	year={2015},
+	publisher={Taylor \& Francis}
 }
 
 @article{tackmann2019rapid,
@@ -109,181 +80,148 @@
 	publisher={Elsevier}
 }
 
-@article{bezanson2017julia,
-	title={Julia: A fresh approach to numerical computing},
-	author={Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B},
-	journal={SIAM review},
-	volume={59},
-	number={1},
-	pages={65--98},
-	year={2017},
-	publisher={SIAM}
-}
-
-@article{foodsecurity2017,
-	Author = {Singh, B.~K. and Trivedi, P. },
-	Journal = {Microbial biotechnology},
-	%Number = 5,
-	Pages = {50–53},
-	%Publisher = {},
-	Title = {Microbiome and the future for food and nutrient security. },
-	doi={10.1111/1751-7915.12592},
-	Volume = 10,
-	Year = 2017}
-
-@article{diease2011,
-	Author = {Murgas Torrazza, R. and Neu, J.},
-	Journal = {Journal of Perinatology},
-	%Number = 4,
-	Pages = {S29-S34},
-	%Publisher = {},
-	Title = {The developing intestinal microbiome and its relationship to health and disease in the neonate.},
-	doi={10.1038/jp.2010.172},
-	Volume =31,
-	Year = 2011}
-
 @misc{google2023,
-    title        = {Sparse and compositionally robust inference of microbial ecological networks},
-    author       = {Google},
-    year         = 2023,
-    note         = {Accessed: 19 April 2023},
-    howpublished = {https://scholar.google.com/citations?view_op=view_citation&hl=en&user=owAHdjcAAAAJ&citation_for_view=owAHdjcAAAAJ:hFOr9nPyWt4C}
+	title        = {Sparse and compositionally robust inference of microbial ecological networks},
+	author       = {Google},
+	year         = 2023,
+	note = {Accessed on April 20, 2023}
+	howpublished = {\url{https://scholar.google.com/citations?view_op=view_citation&hl=en&user=owAHdjcAAAAJ&citation_for_view=owAHdjcAAAAJ:hFOr9nPyWt4C}}
 }
 
 @Article{Bolyen2019,
-author={Bolyen, Evan
-and Rideout, Jai Ram
-and Dillon, Matthew R.
-and Bokulich, Nicholas A.
-and Abnet, Christian C.
-and Al-Ghalith, Gabriel A.
-and Alexander, Harriet
-and Alm, Eric J.
-and Arumugam, Manimozhiyan
-and Asnicar, Francesco
-and Bai, Yang
-and Bisanz, Jordan E.
-and Bittinger, Kyle
-and Brejnrod, Asker
-and Brislawn, Colin J.
-and Brown, C. Titus
-and Callahan, Benjamin J.
-and Caraballo-Rodr{\'{\i}}guez, Andr{\'e}s Mauricio
-and Chase, John
-and Cope, Emily K.
-and Da Silva, Ricardo
-and Diener, Christian
-and Dorrestein, Pieter C.
-and Douglas, Gavin M.
-and Durall, Daniel M.
-and Duvallet, Claire
-and Edwardson, Christian F.
-and Ernst, Madeleine
-and Estaki, Mehrbod
-and Fouquier, Jennifer
-and Gauglitz, Julia M.
-and Gibbons, Sean M.
-and Gibson, Deanna L.
-and Gonzalez, Antonio
-and Gorlick, Kestrel
-and Guo, Jiarong
-and Hillmann, Benjamin
-and Holmes, Susan
-and Holste, Hannes
-and Huttenhower, Curtis
-and Huttley, Gavin A.
-and Janssen, Stefan
-and Jarmusch, Alan K.
-and Jiang, Lingjing
-and Kaehler, Benjamin D.
-and Kang, Kyo Bin
-and Keefe, Christopher R.
-and Keim, Paul
-and Kelley, Scott T.
-and Knights, Dan
-and Koester, Irina
-and Kosciolek, Tomasz
-and Kreps, Jorden
-and Langille, Morgan G. I.
-and Lee, Joslynn
-and Ley, Ruth
-and Liu, Yong-Xin
-and Loftfield, Erikka
-and Lozupone, Catherine
-and Maher, Massoud
-and Marotz, Clarisse
-and Martin, Bryan D.
-and McDonald, Daniel
-and McIver, Lauren J.
-and Melnik, Alexey V.
-and Metcalf, Jessica L.
-and Morgan, Sydney C.
-and Morton, Jamie T.
-and Naimey, Ahmad Turan
-and Navas-Molina, Jose A.
-and Nothias, Louis Felix
-and Orchanian, Stephanie B.
-and Pearson, Talima
-and Peoples, Samuel L.
-and Petras, Daniel
-and Preuss, Mary Lai
-and Pruesse, Elmar
-and Rasmussen, Lasse Buur
-and Rivers, Adam
-and Robeson, Michael S.
-and Rosenthal, Patrick
-and Segata, Nicola
-and Shaffer, Michael
-and Shiffer, Arron
-and Sinha, Rashmi
-and Song, Se Jin
-and Spear, John R.
-and Swafford, Austin D.
-and Thompson, Luke R.
-and Torres, Pedro J.
-and Trinh, Pauline
-and Tripathi, Anupriya
-and Turnbaugh, Peter J.
-and Ul-Hasan, Sabah
-and van der Hooft, Justin J. J.
-and Vargas, Fernando
-and V{\'a}zquez-Baeza, Yoshiki
-and Vogtmann, Emily
-and von Hippel, Max
-and Walters, William
-and Wan, Yunhu
-and Wang, Mingxun
-and Warren, Jonathan
-and Weber, Kyle C.
-and Williamson, Charles H. D.
-and Willis, Amy D.
-and Xu, Zhenjiang Zech
-and Zaneveld, Jesse R.
-and Zhang, Yilong
-and Zhu, Qiyun
-and Knight, Rob
-and Caporaso, J. Gregory},
-title={Reproducible, interactive, scalable and extensible microbiome data science using QIIME 2},
-journal={Nature Biotechnology},
-year={2019},
-month={Aug},
-day={01},
-volume={37},
-number={8},
-pages={852--857},
-issn={1546-1696},
-doi={10.1038/s41587-019-0209-9},
-url={https://doi.org/10.1038/s41587-019-0209-9}
+	author={Bolyen, Evan
+		 and Rideout, Jai Ram
+		 and Dillon, Matthew R.
+		 and Bokulich, Nicholas A.
+		 and Abnet, Christian C.
+		 and Al-Ghalith, Gabriel A.
+		 and Alexander, Harriet
+		 and Alm, Eric J.
+		 and Arumugam, Manimozhiyan
+		 and Asnicar, Francesco
+		 and Bai, Yang
+		 and Bisanz, Jordan E.
+		 and Bittinger, Kyle
+		 and Brejnrod, Asker
+		 and Brislawn, Colin J.
+		 and Brown, C. Titus
+		 and Callahan, Benjamin J.
+		 and Caraballo-Rodr{\'{\i}}guez, Andr{\'e}s Mauricio
+		 and Chase, John
+		 and Cope, Emily K.
+		 and Da Silva, Ricardo
+		 and Diener, Christian
+		 and Dorrestein, Pieter C.
+		 and Douglas, Gavin M.
+		 and Durall, Daniel M.
+		 and Duvallet, Claire
+		 and Edwardson, Christian F.
+		 and Ernst, Madeleine
+		 and Estaki, Mehrbod
+		 and Fouquier, Jennifer
+		 and Gauglitz, Julia M.
+		 and Gibbons, Sean M.
+		 and Gibson, Deanna L.
+		 and Gonzalez, Antonio
+		 and Gorlick, Kestrel
+		 and Guo, Jiarong
+		 and Hillmann, Benjamin
+		 and Holmes, Susan
+		 and Holste, Hannes
+		 and Huttenhower, Curtis
+		 and Huttley, Gavin A.
+		 and Janssen, Stefan
+		 and Jarmusch, Alan K.
+		 and Jiang, Lingjing
+		 and Kaehler, Benjamin D.
+		 and Kang, Kyo Bin
+		 and Keefe, Christopher R.
+		 and Keim, Paul
+		 and Kelley, Scott T.
+		 and Knights, Dan
+		 and Koester, Irina
+		 and Kosciolek, Tomasz
+		 and Kreps, Jorden
+		 and Langille, Morgan G. I.
+		 and Lee, Joslynn
+		 and Ley, Ruth
+		 and Liu, Yong-Xin
+		 and Loftfield, Erikka
+		 and Lozupone, Catherine
+		 and Maher, Massoud
+		 and Marotz, Clarisse
+		 and Martin, Bryan D.
+		 and McDonald, Daniel
+		 and McIver, Lauren J.
+		 and Melnik, Alexey V.
+		 and Metcalf, Jessica L.
+		 and Morgan, Sydney C.
+		 and Morton, Jamie T.
+		 and Naimey, Ahmad Turan
+		 and Navas-Molina, Jose A.
+		 and Nothias, Louis Felix
+		 and Orchanian, Stephanie B.
+		 and Pearson, Talima
+		 and Peoples, Samuel L.
+		 and Petras, Daniel
+		 and Preuss, Mary Lai
+		 and Pruesse, Elmar
+		 and Rasmussen, Lasse Buur
+		 and Rivers, Adam
+		 and Robeson, Michael S.
+		 and Rosenthal, Patrick
+		 and Segata, Nicola
+		 and Shaffer, Michael
+		 and Shiffer, Arron
+		 and Sinha, Rashmi
+		 and Song, Se Jin
+		 and Spear, John R.
+		 and Swafford, Austin D.
+		 and Thompson, Luke R.
+		 and Torres, Pedro J.
+		 and Trinh, Pauline
+		 and Tripathi, Anupriya
+		 and Turnbaugh, Peter J.
+		 and Ul-Hasan, Sabah
+		 and van der Hooft, Justin J. J.
+		 and Vargas, Fernando
+		 and V{\'a}zquez-Baeza, Yoshiki
+		 and Vogtmann, Emily
+		 and von Hippel, Max
+		 and Walters, William
+		 and Wan, Yunhu
+		 and Wang, Mingxun
+		 and Warren, Jonathan
+		 and Weber, Kyle C.
+		 and Williamson, Charles H. D.
+		 and Willis, Amy D.
+		 and Xu, Zhenjiang Zech
+		 and Zaneveld, Jesse R.
+		 and Zhang, Yilong
+		 and Zhu, Qiyun
+		 and Knight, Rob
+		 and Caporaso, J. Gregory},
+	title={Reproducible, interactive, scalable and extensible microbiome data science using QIIME 2},
+	journal={Nature Biotechnology},
+	year={2019},
+	month={Aug},
+	day={01},
+	volume={37},
+	number={8},
+	pages={852--857},
+	issn={1546-1696},
+	doi={10.1038/s41587-019-0209-9},
+	url={https://doi.org/10.1038/s41587-019-0209-9}
 }
 
 @article{delmas2019analysing,
-  title={Analysing ecological networks of species interactions},
-  author={Delmas, Eva and Besson, Mathilde and Brice, Marie-H{\'e}l{\`e}ne and Burkle, Laura A and Dalla Riva, Giulio V and Fortin, Marie-Jos{\'e}e and Gravel, Dominique and Guimar{\~a}es Jr, Paulo R and Hembry, David H and Newman, Erica A and others},
-  journal={Biological Reviews},
-  volume={94},
-  number={1},
-  pages={16--36},
-  year={2019},
-  publisher={Wiley Online Library}
+	title={Analysing ecological networks of species interactions},
+	author={Delmas, Eva and Besson, Mathilde and Brice, Marie-H{\'e}l{\`e}ne and Burkle, Laura A and Dalla Riva, Giulio V and Fortin, Marie-Jos{\'e}e and Gravel, Dominique and Guimar{\~a}es Jr, Paulo R and Hembry, David H and Newman, Erica A and others},
+	journal={Biological Reviews},
+	volume={94},
+	number={1},
+	pages={16--36},
+	year={2019},
+	publisher={Wiley Online Library}
 }
 

--- a/joss-paper/joss.bib
+++ b/joss-paper/joss.bib
@@ -84,7 +84,7 @@
 	title        = {Sparse and compositionally robust inference of microbial ecological networks},
 	author       = {Google},
 	year         = 2023,
-	note = {Accessed on April 20, 2023}
+	note = {Accessed on April 20, 2023},
 	howpublished = {\url{https://scholar.google.com/citations?view_op=view_citation&hl=en&user=owAHdjcAAAAJ&citation_for_view=owAHdjcAAAAJ:hFOr9nPyWt4C}}
 }
 

--- a/joss-paper/joss.bib
+++ b/joss-paper/joss.bib
@@ -82,7 +82,7 @@
 
 @misc{google2023,
 	title        = {Sparse and compositionally robust inference of microbial ecological networks},
-	author       = {Google},
+	author       = {Google Scholar},
 	year         = 2023,
 	note = {Accessed on April 20, 2023},
 	howpublished = {\url{https://scholar.google.com/citations?view_op=view_citation&hl=en&user=owAHdjcAAAAJ&citation_for_view=owAHdjcAAAAJ:hFOr9nPyWt4C}}

--- a/joss-paper/paper.md
+++ b/joss-paper/paper.md
@@ -39,8 +39,8 @@ habitat are known collectively as a microbiome. The microbiomes that occupy the
 human body crucially impact human health in positive and negative ways
 [@berg2020microbiome]. Microbe-microbe and host-microbe interactions may play a
 significant role in many areas; for example, food science
-[@singh2017microbiome; @torrazza2011developing; @foodsecurity2017], health
-science [@torrazza2011developing; @diease2011] and agricultural production
+[@singh2017microbiome; @torrazza2011developing], health
+science [@torrazza2011developing] and agricultural production
 [@berg2020microbiome]. Understanding the functions, interactions, temporal and
 spatial structures, and population dynamics of microbial communities, will lead
 to breakthroughs in those areas. To discover the interactions among microbiota


### PR DESCRIPTION
Removed the double citation of the Singh and Torrazza papers and associated bib entries. Removed the additional Google Scholar bib entry. Deleted numerous references which we are no longer using (or never used) from the bib file.

Used auto indent on the file.